### PR TITLE
[nightshift] best-practice-fix: remove dead code, use built-in min, fix O(n²) dedup

### DIFF
--- a/internal/audit/models.go
+++ b/internal/audit/models.go
@@ -129,7 +129,7 @@ func normalizeTextOr(value string, fallback string) string {
 func boundJSONPayload(value any) any {
 	sanitized := sanitizeJSONValue(value, 0)
 	encoded := serializeJSON(sanitized)
-	if len([]byte(encoded)) <= MaxJSONBytes {
+	if len(encoded) <= MaxJSONBytes {
 		return sanitized
 	}
 	previewChars := MaxJSONBytes / 2
@@ -141,7 +141,7 @@ func boundJSONPayload(value any) any {
 	}
 	return map[string]any{
 		"truncated":      true,
-		"original_bytes": len([]byte(encoded)),
+		"original_bytes": len(encoded),
 		"preview":        truncateText(encoded, previewChars),
 	}
 }
@@ -214,7 +214,7 @@ func sanitizeMap(m map[string]any, depth int) any {
 }
 
 func sanitizeList(values []any, depth int) any {
-	out := make([]any, 0, minInt(len(values), MaxJSONItems))
+	out := make([]any, 0, min(len(values), MaxJSONItems))
 	for i, item := range values {
 		if i >= MaxJSONItems {
 			out = append(out, TruncatedValue)
@@ -225,12 +225,7 @@ func sanitizeList(values []any, depth int) any {
 	return out
 }
 
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
+
 
 func truncateText(text string, maxChars int) string {
 	if maxChars <= 0 {

--- a/internal/policy/models.go
+++ b/internal/policy/models.go
@@ -28,6 +28,7 @@ func (p RoleToolPolicy) Allows(toolName string) bool {
 }
 
 func (p *RoleToolPolicy) Normalize() error {
+	seen := make(map[string]struct{}, len(p.Allow))
 	var out []string
 	for _, raw := range p.Allow {
 		name := strings.TrimSpace(raw)
@@ -38,14 +39,8 @@ func (p *RoleToolPolicy) Normalize() error {
 			p.Allow = []string{ToolWildcard}
 			return nil
 		}
-		seen := false
-		for _, existing := range out {
-			if existing == name {
-				seen = true
-				break
-			}
-		}
-		if !seen {
+		if _, exists := seen[name]; !exists {
+			seen[name] = struct{}{}
 			out = append(out, name)
 		}
 	}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -224,7 +224,6 @@ func (g *gateway) makeToolHandler(toolName string) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		started := time.Now()
 		statusCode := int64(500)
-		upstreamCalled := false
 
 		decision := defaultDecisionPayload()
 		var responseJSON any = safeErrorPayload(int(statusCode), internalErrorMessage)
@@ -292,7 +291,6 @@ func (g *gateway) makeToolHandler(toolName string) mcp.ToolHandler {
 		decision["rate"] = rateDecision
 
 		// Forward to upstream
-		upstreamCalled = true
 		args := map[string]any{}
 		if req.Params != nil && len(req.Params.Arguments) > 0 {
 			_ = json.Unmarshal(req.Params.Arguments, &args)
@@ -301,10 +299,7 @@ func (g *gateway) makeToolHandler(toolName string) mcp.ToolHandler {
 		if err != nil {
 			statusCode = 502
 			responseJSON = safeExceptionPayload(int(statusCode), err)
-			if upstreamCalled {
-				return nil, &jsonrpc.Error{Code: statusCode, Message: upstreamFailureMessage}
-			}
-			return nil, &jsonrpc.Error{Code: 500, Message: internalErrorMessage}
+			return nil, &jsonrpc.Error{Code: statusCode, Message: upstreamFailureMessage}
 		}
 
 		statusCode = 200


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** best-practice-fix
**Category:** pr

**Changes:**

1. **Remove custom `minInt` helper** (`audit/models.go`) — Go 1.21+ has built-in `min()`, project uses Go 1.25.6. Replaced all usages.

2. **Remove dead code** (`proxy/server.go`) — `upstreamCalled` variable was set to `true` unconditionally (line 295) before the only check (line 304), making the `else` branch unreachable. Removed variable and simplified to direct return.

3. **Avoid unnecessary allocation** (`audit/models.go`) — `len([]byte(encoded))` creates a temporary byte slice just to check length. `len(encoded)` returns the same byte count for strings (Go strings are UTF-8 byte sequences). Both occurrences fixed.

4. **O(n²) → O(n) duplicate detection** (`policy/models.go`) — `RoleToolPolicy.Normalize()` used linear scan per item to detect duplicates. Replaced with a `map[string]struct{}` for O(1) lookups.

All changes are net-negative (8 additions, 23 deletions) with no behavioral changes.

Merge if useful, close if not.